### PR TITLE
BFV 09/08/2017: Added NHGRI file check before attempting download

### DIFF
--- a/src/merp.py
+++ b/src/merp.py
@@ -15,12 +15,18 @@ class Merp():
             print "Generating IVFs for traits in NHGRI GWAS catalog related to " + keyword + " . . ."
         else:
             print "Generating IVFs for all traits in NHGRI GWAS catalog . . ."
-        with open('./data/finalgwas.txt', 'w') as gwas:
-            r = requests.get('http://www.genome.gov/admin/gwascatalog.txt')
-            text = r.text
-            unix_result = text.replace('\r', '')
-            encoded_result = unix_result.encode('utf-8')
-            gwas.write(encoded_result)
+
+        ## BFV 09/01/2017: added a file check for the nhgri catalog before downloading.
+        if os.path.isfile('./data/finalgwas.txt') == False:
+            with open('./data/finalgwas.txt', 'w') as gwas:
+                r = requests.get('http://www.genome.gov/admin/gwascatalog.txt')
+                text = r.text
+                unix_result = text.replace('\r', '')
+                encoded_result = unix_result.encode('utf-8')
+                gwas.write(encoded_result)
+        else:
+            print "Already have NHGRI catalog file. If you wish to re-download, please remove ./data/finalgwas.txt\n"
+
         with open('./data/finalgwas.txt',"r") as f:
             line = f.readlines()
             result_list = []


### PR DESCRIPTION
I just added a line or two that checks if the finalgwas.txt file is present; if not, it attempts to download from the NHGRI data base.

if it is present, gives a warning note and then proceeds to use that file (without attempting to download again). 